### PR TITLE
Fix issue with `skip!` and with cloning `@config`.

### DIFF
--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -17,6 +17,12 @@ module CSVImporter
     def after_save(block)
       self.after_save_blocks << block
     end
+
+    def dup
+      # Make sure we dup the attributes as well as variable itself
+      self.class.new(attribute_set.get(self))
+    end
+    alias clone dup
   end
 end
 

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -10,7 +10,7 @@ module CSVImporter
     attribute :row_array, Array[String]
     attribute :model_klass
     attribute :identifiers, Array[Symbol]
-    attribute :after_build_blocks, Array[Proc], default: []
+    attribute :after_build_blocks, Array[Proc], default: proc { [] }
     attribute :skip, Boolean, default: false
 
     # The model to be persisted
@@ -90,7 +90,9 @@ module CSVImporter
       return nil if identifiers.empty?
 
       model = build_model
+      old_skip = self.skip
       set_attributes(model)
+      self.skip = old_skip
       query = Hash[
         identifiers.map { |identifier| [ identifier, model.public_send(identifier) ] }
       ]

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -544,6 +544,20 @@ BOB@example.com,true,bob,,"
     end
   end
 
+  describe "config" do
+    it "is properly cloned" do
+      import = ImportUserCSV.new(content: "") do
+        after_build { }
+      end
+
+      import = ImportUserCSV.new(content: "") do
+        after_build { }
+      end
+
+      expect(import.config.after_build_blocks.length).to eq(1)
+    end
+  end
+
   describe "skipping" do
     it "could skip via throw :skip" do
       csv_content = "email,confirmed,first_name,last_name
@@ -557,6 +571,20 @@ mark@example.com,false,mark,new_last_name"
 
       import.run!
       expect(import.report.message).to eq "Import completed: 1 created, 1 update skipped"
+    end
+
+    it "doesn't call skip! twice" do
+      csv_content = "email,confirmed,first_name,last_name
+bob@example.com,true,bob,,
+mark@example.com,false,mark,new_last_name"
+      import = ImportUserCSV.new(content: csv_content) do
+        after_build do |user|
+          skip! unless user.persisted?
+        end
+      end
+
+      import.run!
+      expect(import.report.message).to eq "Import completed: 1 updated, 1 create skipped"
     end
   end
 end


### PR DESCRIPTION
The `after_build` blocks are called both before a model is found and after (via `set_attributes`).  This means if you fire `skip!` based on some logic that only applies after a model is found it will be called before.  Calling something like `skip! unless model.persisted?` is a good example of this.

While fixing this, I also noticed that configuring an importer via the `ImporterClass.new do { ... }` syntax didn't properly clone the configuration, so things such as the configuration's `after_build_blocks` were all pointing to the same object.  This fixes that by adapting some syntax from Virtus' Value Object code.
