### PR TITLE
Introduce support for Converters

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -2,6 +2,7 @@ require "csv"
 require "virtus"
 
 require "csv_importer/version"
+require "csv_importer/converter"
 require "csv_importer/csv_reader"
 require "csv_importer/column_definition"
 require "csv_importer/column"

--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -23,11 +23,15 @@ module CSVImporter
   #     model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
   #   end
   #
+  #   # reuse date parsing logic across importers
+  #   # DateImporterParser = ->(date) { complex logic... }
+  #   # column :birth_date, to: DateImporterParser
+  #
   class ColumnDefinition
     include Virtus.model
 
     attribute :name, Symbol
-    attribute :to # Symbol or Proc
+    attribute :to # Symbol, Proc, or Converter
     attribute :as # Symbol, String, Regexp, Array
     attribute :required, Boolean
 

--- a/lib/csv_importer/converter.rb
+++ b/lib/csv_importer/converter.rb
@@ -1,0 +1,50 @@
+module CSVImporter
+  class Converter
+    DEFAULT = ->(value) { value }
+
+    def self.infer(proc_or_class)
+      return ProcConverter.new(proc_or_class) if proc_or_class.is_a?(Proc)
+      return proc_or_class.new if proc_or_class.is_a?(Class)
+
+      Converter.new
+    end
+
+    def parse(csv_value)
+      csv_value
+    end
+
+    def convert(csv_value, model, attribute_name)
+      value = parse(csv_value)
+
+      assign(model, attribute_name, value)
+    end
+
+    private
+
+    def assign(model, attribute_name, value)
+      model.public_send("#{ attribute_name }=", value)
+    end
+
+    class ProcConverter < self
+      def initialize(block = DEFAULT)
+        @proc = block
+      end
+
+      def parse(csv_value)
+        case @proc.arity
+        when 1 then @proc.call(csv_value)
+        else
+          csv_value
+        end
+      end
+
+      def convert(csv_value, model, attribute_name)
+        case @proc.arity
+        when 2 then @proc.call(csv_value, model)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -51,21 +51,8 @@ module CSVImporter
 
     # Set the attribute using the column_definition and the csv_value
     def set_attribute(model, column_definition, csv_value)
-      if column_definition.to && column_definition.to.is_a?(Proc)
-        to_proc = column_definition.to
-
-        case to_proc.arity
-        when 1 # to: ->(email) { email.downcase }
-          model.public_send("#{column_definition.name}=", to_proc.call(csv_value))
-        when 2 # to: ->(published, post) { post.published_at = Time.now if published == "true" }
-          to_proc.call(csv_value, model)
-        else
-          raise ArgumentError, "`to` proc can only have 1 or 2 arguments"
-        end
-      else
-        attribute = column_definition.attribute
-        model.public_send("#{attribute}=", csv_value)
-      end
+      converter = Converter.infer(column_definition.to)
+      converter.convert(csv_value, model, column_definition.attribute)
 
       model
     end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -14,6 +14,7 @@ describe CSVImporter do
     attribute :l_name
     attribute :confirmed_at
     attribute :created_by_user_id
+    attribute :birth_date
 
     validates_presence_of :email
     validates_format_of :email, with: /[^@]+@[^@]/ # contains one @ symbol
@@ -57,6 +58,15 @@ describe CSVImporter do
     end
   end
 
+  class DateConverter < CSVImporter::Converter
+    def parse(csv_value)
+      begin
+        Date.strptime(csv_value, '%m/%d/%y')
+      rescue
+      end
+    end
+  end
+
   class ImportUserCSV
     include CSVImporter
 
@@ -65,6 +75,7 @@ describe CSVImporter do
     column :email, required: true, as: /email/i, to: ->(email) { email.downcase }
     column :f_name, as: :first_name, required: true
     column :last_name,  to: :l_name
+    column :birth_date, to: DateConverter
     column :confirmed,  to: ->(confirmed, model) do
       model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
     end
@@ -101,8 +112,8 @@ describe CSVImporter do
 
   describe "happy path" do
     it 'imports' do
-      csv_content = "email,confirmed,first_name,last_name
-BOB@example.com,true,bob,,"
+      csv_content = "email,confirmed,first_name,last_name,birth_date
+BOB@example.com,true,bob,,03/19/05"
 
       import = ImportUserCSV.new(content: csv_content)
       expect(import.rows.size).to eq(1)
@@ -114,7 +125,8 @@ BOB@example.com,true,bob,,"
           "email" => "BOB@example.com",
           "first_name" => "bob",
           "last_name" => "",
-          "confirmed" => "true"
+          "confirmed" => "true",
+          "birth_date" => "03/19/05"
         }
       )
 
@@ -131,7 +143,8 @@ BOB@example.com,true,bob,,"
         "email" => "bob@example.com", # was downcased!
         "f_name" => "bob",
         "l_name" => "",
-        "confirmed_at" => Time.new(2012)
+        "confirmed_at" => Time.new(2012),
+        "birth_date" => Date.new(2005, 3, 19)
       )
     end
   end
@@ -201,7 +214,7 @@ bob@example.com,true,,last,"
       import = ImportUserCSV.new(content: csv_content)
 
       expect(import.header.missing_required_columns).to be_empty
-      expect(import.header.missing_columns).to eq(["last_name", "confirmed"])
+      expect(import.header.missing_columns).to eq(["last_name", "birth_date", "confirmed"])
     end
   end
 
@@ -217,8 +230,8 @@ bob@example.com,true,,last,"
 
   describe "find or create" do
     it "finds or create via identifier" do
-      csv_content = "email,confirmed,first_name,last_name
-bob@example.com,true,bob,,
+      csv_content = "email,confirmed,first_name,last_name,birth_date
+bob@example.com,true,bob,,03/19/05
 mark@example.com,false,mark,new_last_name"
       import = ImportUserCSV.new(content: csv_content)
 
@@ -234,7 +247,8 @@ mark@example.com,false,mark,new_last_name"
         email: "bob@example.com",
         f_name: "bob",
         l_name: "",
-        confirmed_at: Time.new(2012)
+        confirmed_at: Time.new(2012),
+        birth_date: Date.new(2005, 3, 19)
       )
 
       model = import.report.updated_rows.first.model

--- a/spec/fixtures/valid_csv.csv
+++ b/spec/fixtures/valid_csv.csv
@@ -1,2 +1,2 @@
-email,confirmed,first_name,last_name
-bob@example.com,true,bob,,
+email,confirmed,first_name,last_name,birth_date
+bob@example.com,true,bob,,03/19/05


### PR DESCRIPTION
Allow a user to specify a Converter subclass, instead of Proc, when defining a Column.

Ensures that complex logic can be unit tested as a separate class, instead of inside the proc, and can also be more easily reused across attributes or even Importers.

We're using this to support a myriad of date formats that ActiveSupport/Rails doesn't parse correctly out of the box, and reusing this converter across a couple attributes and multiple importers is proving quite useful.  Allows you to unit test your converter as well, instead of relying on a Proc.