### PR TITLE
Provide a simple description field in the column definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,32 @@ UserImport.new(file: csv_file) do
 end
 ```
 
+### Provide user info regarding column purpose
+
+You may want to pull the schema for the importer dynamically and list out the
+supported fields along with a description, to help guide users through an import
+process on valid content.
+
+```ruby
+class ImportUserCSV
+  model User
+
+  column :active, to: ->(value) { %w(y yes true active).include?(value.downcase) }, description: %q{Indicate if active using "Y", "yes", "true", "active" or just "no"}
+
+  # optionally use I18n
+  column :active, to: ->(value) {}, description: I18n.t('my.custom.scope.active')
+end
+```
+
+To access this information and potentially display to users before uploading a
+file to import:
+
+```ruby
+ImportUserCSV.config.column_definitions.each do |column|
+  puts "#{ column.name.to_s.titleize } - #{ column.description }"
+end
+```
+
 
 ### Validate the header
 

--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -18,6 +18,9 @@ module CSVImporter
   #   # email will be downcased
   #   column :email, to: ->(email) { email.downcase }
   #
+  #   # column defined with description to show user info about schema
+  #   column :active, description: %q{Can provide "Y", "Yes", "true" or simply "no"}
+  #
   #   # transform `confirmed` to `confirmed_at`
   #   column :confirmed, to: ->(confirmed, model) do
   #     model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
@@ -30,6 +33,7 @@ module CSVImporter
     attribute :to # Symbol or Proc
     attribute :as # Symbol, String, Regexp, Array
     attribute :required, Boolean
+    attribute :description, String
 
     # The model attribute that this column targets
     def attribute


### PR DESCRIPTION
Allows us to provide helpful information directly inline in the importer, where we are defining the schema for an import.

For systems where we've standardized imports and share controller/view partials in Rails, this helps tremendously.