### PR TITLE
after_save supports block with arity of 2 for access to raw attributes

### DIFF
--- a/lib/csv_importer/runner.rb
+++ b/lib/csv_importer/runner.rb
@@ -63,7 +63,16 @@ module CSVImporter
           end
 
           add_to_report(row, tags)
-          after_save_blocks.each { |block| block.call(row.model) }
+
+          after_save_blocks.each do |block|
+            case block.arity
+            when 0 then block.call
+            when 1 then block.call(row.model)
+            when 2 then block.call(row.model, row.csv_attributes)
+            else
+              raise ArgumentError, "after_save block of arity #{ block.arity } is not supported"
+            end
+          end
         end
       end
     end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -577,6 +577,13 @@ BOB@example.com,true,bob,,"
         after_save do
           saves_count += 1
         end
+
+        after_save do |user, attributes|
+          # representing maybe a realistic OtherResource.find_by(name: 'invalid')
+          if user.email == 'invalid'
+            user.errors.add(:email, "'#{ attributes['email'] }' could not be found")
+          end
+        end
       end
 
       expect {
@@ -584,6 +591,9 @@ BOB@example.com,true,bob,,"
       }.to change { success_array }.from([]).to([true, false])
 
       expect(saves_count).to eq 2
+
+      failed_row = import.report.failed_to_create_rows.first
+      expect(failed_row.model.errors[:email]).to include("'invalid' could not be found")
     end
   end
 


### PR DESCRIPTION
This allows us to inspect the raw contents from the CSV if the record
encountered some errors.

The value in the CSV might be present, but yet when transformed
disappears if invalid (say referencing another resource that is not
accessible).

We use like so:

```ruby
class Importer
  model Task

  column :assignee, to: ->(name) { User.active.find_by(name: name) }

  after_save do |task, attributes|
    if task.errors[:assignee].present? && attributes['Assignee'].present?
      task.errors.add(:assignee, "'#{ attributes['Assignee'] }' is not part of this project."
    end
  end
end
```