### PR TITLE
Allow accessing a hash of metadata on ColumnDefinition

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,35 @@ UserImport.new(file: csv_file) do
 end
 ```
 
+### Store metadata on the column description
+
+You may find yourself wanting to store arbitrary metadata about a column.
+
+For example, you may want to pull the schema for the importer dynamically and list out the
+supported fields along with a description, to help guide users through an import
+process on valid content.
+
+This can be accomplished using the metadata Hash.
+
+```ruby
+class ImportUserCSV
+  model User
+
+  column :active, to: ->(value) { %w(y yes true active).include?(value.downcase) }, meta: { description: %q{Indicate if active using "Y", "yes", "true", "active" or just "no"} }
+
+  # optionally use I18n
+  column :active, to: ->(value) {}, meta: { description: I18n.t('my.custom.scope.active') }
+end
+```
+
+To access this information and potentially display to users before uploading a
+file to import:
+
+```ruby
+ImportUserCSV.config.column_definitions.each do |column|
+  puts "#{ column.name.to_s.titleize } - #{ column.metadata[:description] }"
+end
+```
 
 ### Validate the header
 

--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -18,6 +18,9 @@ module CSVImporter
   #   # email will be downcased
   #   column :email, to: ->(email) { email.downcase }
   #
+  #   # column defined with metadata
+  #   column :active, meta: { description: %q{Can provide "Y", "Yes", "true" or simply "no"} }
+  #
   #   # transform `confirmed` to `confirmed_at`
   #   column :confirmed, to: ->(confirmed, model) do
   #     model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
@@ -30,6 +33,7 @@ module CSVImporter
     attribute :to # Symbol or Proc
     attribute :as # Symbol, String, Regexp, Array
     attribute :required, Boolean
+    attribute :meta, Hash, default: {}
 
     # The model attribute that this column targets
     def attribute

--- a/spec/csv_importer/column_definition_spec.rb
+++ b/spec/csv_importer/column_definition_spec.rb
@@ -2,6 +2,24 @@ require "spec_helper"
 
 module CSVImporter
   describe ColumnDefinition do
+    describe '.meta' do
+      it 'defaults to an empty Hash' do
+        expect(subject.meta).to eq(Hash.new)
+      end
+
+      it 'does not transform values' do
+        subject.meta[:key] = 19.0
+
+        expect(subject.meta[:key]).to eq(19.0)
+      end
+
+      it 'does not transform keys' do
+        subject.meta['key'] = 19.0
+
+        expect(subject.meta[:key]).to eq(nil)
+      end
+    end
+
     describe "#match?" do
 
       matcher :match do |name|


### PR DESCRIPTION
Replaces #67 as a generic way to associate a Hash of data with a `ColumnDefinition` as you please.