### PR TITLE
Introduces Parsers

### DIFF
--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -29,6 +29,7 @@ module CSVImporter
     attribute :name, Symbol
     attribute :to # Symbol or Proc
     attribute :as # Symbol, String, Regexp, Array
+    attribute :parser # Object responding to #call (Proc or Class)
     attribute :required, Boolean
 
     # The model attribute that this column targets

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -52,21 +52,7 @@ module CSVImporter
 
     # Set the attribute using the column_definition and the csv_value
     def set_attribute(model, column_definition, csv_value)
-      if column_definition.to && column_definition.to.is_a?(Proc)
-        to_proc = column_definition.to
-
-        case to_proc.arity
-        when 1 # to: ->(email) { email.downcase }
-          model.public_send("#{column_definition.name}=", to_proc.call(csv_value))
-        when 2 # to: ->(published, post) { post.published_at = Time.now if published == "true" }
-          to_proc.call(csv_value, model)
-        else
-          raise ArgumentError, "`to` proc can only have 1 or 2 arguments"
-        end
-      else
-        attribute = column_definition.attribute
-        model.public_send("#{attribute}=", csv_value)
-      end
+      deprecated_attribute_setter(model, column_definition, csv_value)
 
       model
     end
@@ -112,6 +98,24 @@ module CSVImporter
     end
 
     private
+
+    def deprecated_attribute_setter(model, column_definition, csv_value)
+      if column_definition.to && column_definition.to.is_a?(Proc)
+        to_proc = column_definition.to
+
+        case to_proc.arity
+        when 1 # to: ->(email) { email.downcase }
+          model.public_send("#{column_definition.name}=", to_proc.call(csv_value))
+        when 2 # to: ->(published, post) { post.published_at = Time.now if published == "true" }
+          to_proc.call(csv_value, model)
+        else
+          raise ArgumentError, "`to` proc can only have 1 or 2 arguments"
+        end
+      else
+        attribute = column_definition.attribute
+        model.public_send("#{attribute}=", csv_value)
+      end
+    end
 
     def model_identifiers(model)
       if identifiers.is_a?(Proc)

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -105,7 +105,7 @@ module CSVImporter
 
         case to_proc.arity
         when 1 # to: ->(email) { email.downcase }
-          model.public_send("#{column_definition.name}=", to_proc.call(csv_value))
+          assign_attribute(model, column_definition.name, to_proc.call(csv_value))
         when 2 # to: ->(published, post) { post.published_at = Time.now if published == "true" }
           to_proc.call(csv_value, model)
         else
@@ -117,8 +117,11 @@ module CSVImporter
     end
 
     def fallback_assignment(model, column_definition, csv_value)
-      attribute = column_definition.attribute
-      model.public_send("#{attribute}=", csv_value)
+      assign_attribute(model, column_definition.attribute, csv_value)
+    end
+
+    def assign_attribute(model, attribute_name, value)
+      model.public_send("#{ attribute_name }=", value)
     end
 
     def model_identifiers(model)

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -112,9 +112,13 @@ module CSVImporter
           raise ArgumentError, "`to` proc can only have 1 or 2 arguments"
         end
       else
-        attribute = column_definition.attribute
-        model.public_send("#{attribute}=", csv_value)
+        fallback_assignment(model, column_definition, csv_value)
       end
+    end
+
+    def fallback_assignment(model, column_definition, csv_value)
+      attribute = column_definition.attribute
+      model.public_send("#{attribute}=", csv_value)
     end
 
     def model_identifiers(model)

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -14,6 +14,7 @@ describe CSVImporter do
     attribute :l_name
     attribute :confirmed_at
     attribute :created_by_user_id
+    attribute :birth_date
 
     validates_presence_of :email
     validates_format_of :email, with: /[^@]+@[^@]/ # contains one @ symbol
@@ -57,6 +58,15 @@ describe CSVImporter do
     end
   end
 
+  class DateParser
+    def self.call(csv_value)
+      begin
+        Date.strptime(csv_value, '%m/%d/%y')
+      rescue
+      end
+    end
+  end
+
   class ImportUserCSV
     include CSVImporter
 
@@ -65,6 +75,7 @@ describe CSVImporter do
     column :email, required: true, as: /email/i, to: ->(email) { email.downcase }
     column :f_name, as: :first_name, required: true
     column :last_name,  to: :l_name
+    column :birth_date, parser: DateParser
     column :confirmed,  to: ->(confirmed, model) do
       model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
     end
@@ -101,8 +112,8 @@ describe CSVImporter do
 
   describe "happy path" do
     it 'imports' do
-      csv_content = "email,confirmed,first_name,last_name
-BOB@example.com,true,bob,,"
+      csv_content = "email,confirmed,first_name,last_name,birth_date
+BOB@example.com,true,bob,,03/19/05"
 
       import = ImportUserCSV.new(content: csv_content)
       expect(import.rows.size).to eq(1)
@@ -114,7 +125,8 @@ BOB@example.com,true,bob,,"
           "email" => "BOB@example.com",
           "first_name" => "bob",
           "last_name" => "",
-          "confirmed" => "true"
+          "confirmed" => "true",
+          "birth_date" => "03/19/05"
         }
       )
 
@@ -131,7 +143,8 @@ BOB@example.com,true,bob,,"
         "email" => "bob@example.com", # was downcased!
         "f_name" => "bob",
         "l_name" => "",
-        "confirmed_at" => Time.new(2012)
+        "confirmed_at" => Time.new(2012),
+        "birth_date" => Date.new(2005, 3, 19)
       )
     end
 
@@ -222,7 +235,7 @@ bob@example.com,true,,last,"
       import = ImportUserCSV.new(content: csv_content)
 
       expect(import.header.missing_required_columns).to be_empty
-      expect(import.header.missing_columns).to eq(["last_name", "confirmed"])
+      expect(import.header.missing_columns).to eq(["last_name", "birth_date", "confirmed"])
     end
   end
 
@@ -238,8 +251,8 @@ bob@example.com,true,,last,"
 
   describe "find or create" do
     it "finds or create via identifier" do
-      csv_content = "email,confirmed,first_name,last_name
-bob@example.com,true,bob,,
+      csv_content = "email,confirmed,first_name,last_name,birth_date
+bob@example.com,true,bob,,03/19/05
 mark@example.com,false,mark,new_last_name"
       import = ImportUserCSV.new(content: csv_content)
 
@@ -255,7 +268,8 @@ mark@example.com,false,mark,new_last_name"
         email: "bob@example.com",
         f_name: "bob",
         l_name: "",
-        confirmed_at: Time.new(2012)
+        confirmed_at: Time.new(2012),
+        birth_date: Date.new(2005, 3, 19)
       )
 
       model = import.report.updated_rows.first.model

--- a/spec/fixtures/valid_csv.csv
+++ b/spec/fixtures/valid_csv.csv
@@ -1,2 +1,2 @@
-email,confirmed,first_name,last_name
-bob@example.com,true,bob,,
+email,confirmed,first_name,last_name,birth_date
+bob@example.com,true,bob,,03/19/05


### PR DESCRIPTION
Replaces #61 by supporting the `to` syntax with procs, and introducing a new `parser` option.  Allows a user to define a parser as a Proc or class, passed as an option that takes precedence over `to`.

Does not add any explicit deprecations, as there isn't a full replacement for usage of `to` with a block accepting 2 arguments right now.

```ruby
class UserImporter
  column :renewed_at, parser: DateParser

  # or

  column :renewed_at, parser: ->(value) { Chronic.parse(value) } 
end
```