### PR TITLE
`to` supports anything that responds to `call`...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Master
+
+* Improve algorithm to detect separators. #88 by @brain-geek
+
 ## [0.6.0] - 2018-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ Like very advanced stuff? We grant you access to the [`column`](https://github.c
   end
 ```
 
+Note that `to:` accepts anything that responds to call and take 1, 2 or
+3 arguments.
+
+```ruby
+class ImportUserCSV
+  include CSVImporter
+
+  model User
+
+  column :birth_date, to: DateTransformer
+  column :renewal_date, to: DateTransformer
+  column :next_renewal_at, to: ->(value) { Time.at(value.to_i) }
+end
+
+class DateTransformer
+  def self.call(date)
+    Date.strptime(date, '%m/%d/%y')
+  end
+end
+```
+
 Now, what if the user does not provide the email column? It's not worth
 running the import, we should just reject the CSV file right away.
 That's easy:
@@ -205,7 +226,6 @@ import.valid_header? # => false
 import.report.status # => :invalid_header
 import.report.message # => "The following columns are required: 'email'"
 ```
-
 
 ### Update or Create
 

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -61,14 +61,18 @@ describe CSVImporter do
   class ImportUserCSV
     include CSVImporter
 
+    class ConfirmedProcessor
+      def self.call(confirmed, model)
+        model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
+      end
+    end
+
     model User
 
     column :email, required: true, as: /email/i, to: ->(email) { email.downcase }
     column :f_name, as: :first_name, required: true
     column :last_name,  to: :l_name
-    column :confirmed,  to: ->(confirmed, model) do
-      model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
-    end
+    column :confirmed,  to: ConfirmedProcessor
     column :extra, as: /extra/i, to: ->(value, model, column) do
       model.custom_fields[column.name] = value
     end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -495,7 +495,7 @@ bob@example.com,false,,in,,,"""|
     import = ImportUserCSV.new(content: csv_content).run!
 
     expect(import).to_not be_success
-    expect(import.message).to eq "Unclosed quoted field on line 3."
+    expect(import.message).to include "Unclosed quoted field"
   end
 
   it "matches columns via regexp" do


### PR DESCRIPTION
`to` can now accepts anything that responds to `call` so that we can define (and re-use!) more complex "parsers" or "transformers" using good ol' classes.

This is inspired by #61 and #71 by @macfanatic.

TODO:

- [x] Update README using #71 change.