### PR TITLE
Allow passing column object to `to` Proc.

### DIFF
--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -41,17 +41,17 @@ module CSVImporter
           # can't dup Symbols, Integer etc...
         end
 
-        column_definition = column.definition
-        next if column_definition.nil?
+        next if column.definition.nil?
 
-        set_attribute(model, column_definition, value)
+        set_attribute(model, column, value)
       end
 
       model
     end
 
     # Set the attribute using the column_definition and the csv_value
-    def set_attribute(model, column_definition, csv_value)
+    def set_attribute(model, column, csv_value)
+      column_definition = column.definition
       if column_definition.to && column_definition.to.is_a?(Proc)
         to_proc = column_definition.to
 
@@ -60,6 +60,8 @@ module CSVImporter
           model.public_send("#{column_definition.name}=", to_proc.call(csv_value))
         when 2 # to: ->(published, post) { post.published_at = Time.now if published == "true" }
           to_proc.call(csv_value, model)
+        when 3 # to: ->(field_value, post, column) { post.hash_field[column.name] = field_value }
+          to_proc.call(csv_value, model, column)
         else
           raise ArgumentError, "`to` proc can only have 1 or 2 arguments"
         end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -14,6 +14,7 @@ describe CSVImporter do
     attribute :l_name
     attribute :confirmed_at
     attribute :created_by_user_id
+    attribute :custom_fields, Hash
 
     validates_presence_of :email
     validates_format_of :email, with: /[^@]+@[^@]/ # contains one @ symbol
@@ -68,6 +69,9 @@ describe CSVImporter do
     column :confirmed,  to: ->(confirmed, model) do
       model.confirmed_at = confirmed == "true" ? Time.new(2012) : nil
     end
+    column :extra, as: /extra/i, to: ->(value, model, column) do
+      model.custom_fields[column.name] = value
+    end
 
     identifier :email # will find_or_update via
 
@@ -101,8 +105,8 @@ describe CSVImporter do
 
   describe "happy path" do
     it 'imports' do
-      csv_content = "email,confirmed,first_name,last_name
-BOB@example.com,true,bob,,"
+      csv_content = "email,confirmed,first_name,last_name,extra_1,extra_2
+BOB@example.com,true,bob,,meta1,meta2"
 
       import = ImportUserCSV.new(content: csv_content)
       expect(import.rows.size).to eq(1)
@@ -114,7 +118,9 @@ BOB@example.com,true,bob,,"
           "email" => "BOB@example.com",
           "first_name" => "bob",
           "last_name" => "",
-          "confirmed" => "true"
+          "confirmed" => "true",
+          "extra_1" => "meta1",
+          "extra_2" => "meta2",
         }
       )
 
@@ -131,7 +137,11 @@ BOB@example.com,true,bob,,"
         "email" => "bob@example.com", # was downcased!
         "f_name" => "bob",
         "l_name" => "",
-        "confirmed_at" => Time.new(2012)
+        "confirmed_at" => Time.new(2012),
+        "custom_fields" => {
+          "extra_1" => "meta1",
+          "extra_2" => "meta2"
+        }
       )
     end
 
@@ -222,7 +232,8 @@ bob@example.com,true,,last,"
       import = ImportUserCSV.new(content: csv_content)
 
       expect(import.header.missing_required_columns).to be_empty
-      expect(import.header.missing_columns).to eq(["last_name", "confirmed"])
+      expect(import.header.missing_columns)
+        .to eq(["last_name", "confirmed", "extra"])
     end
   end
 


### PR DESCRIPTION
This allows mapping of arbitrary fields based on the original column name.

See #48 

A real-world issue I have to deal with is illustrated in the tests. Basically having a set of fields we want to match to a JSON(B) attribute requires the original column name information.

@pcreux please take a look when you have a chance.

Thanks a lot! :bowing_man: 