### PR TITLE
Adding after_read callback, and some CSVReader methods for updating i…

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -69,10 +69,17 @@ module CSVImporter
 
   # Initialize and return the `Row`s for the current CSV file
   def rows
+    # Run the after_read callback first
+    config.after_read_blocks.each { |block| instance_exec(csv, &block) }
+
     csv.rows.map.with_index(2) do |row_array, line_number|
       Row.new(header: header, line_number: line_number, row_array: row_array, model_klass: config.model,
               identifiers: config.identifiers, after_build_blocks: config.after_build_blocks)
     end
+  end
+
+  def add_row(args)
+    csv.add_row(args)
   end
 
   def valid_header?

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -9,6 +9,7 @@ module CSVImporter
     attribute :when_invalid, Symbol, default: proc { :skip }
     attribute :after_build_blocks, Array[Proc], default: []
     attribute :after_save_blocks, Array[Proc], default: []
+    attribute :after_read_blocks, Array[Proc], default: []
 
     def initialize_copy(orig)
       super
@@ -16,6 +17,11 @@ module CSVImporter
       self.identifiers = orig.identifiers.dup
       self.after_save_blocks = orig.after_save_blocks.dup
       self.after_build_blocks = orig.after_build_blocks.dup
+      self.after_read_blocks = orig.after_read_blocks.dup
+    end
+
+    def after_read(block)
+      self.after_read_blocks << block
     end
 
     def after_build(block)

--- a/lib/csv_importer/csv_reader.rb
+++ b/lib/csv_importer/csv_reader.rb
@@ -19,6 +19,20 @@ module CSVImporter
       end
     end
 
+    def add_row(args)
+      cells = Array.new(header.size, "")
+      args.stringify_keys!
+
+      args.each do |h, val|
+        if header.include?(h)
+          cells.insert(header.index(h), val)
+        end
+      end
+
+      @csv_rows = sanitize_cells(@csv_rows << cells)
+      @rows = csv_rows[1..-1]
+    end
+
     # Returns the header as an Array of Strings
     def header
       @header ||= csv_rows.first
@@ -27,6 +41,22 @@ module CSVImporter
     # Returns the rows as an Array of Arrays of Strings
     def rows
       @rows ||= csv_rows[1..-1]
+    end
+
+    # Gets the value for a specific row array at the header_string column
+    def get_from_row_array(row_array, header_string)
+      idx = header.index(header_string)
+      if row_array.size >= idx
+        row_array[idx]
+      end
+    end
+
+    # Sets the value for a specific row array at the header_string column
+    def set_in_row_array(row_array, header_string, val)
+      idx = header.index(header_string)
+      if row_array.size >= idx
+        row_array[idx] = val
+      end
     end
 
     private

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -27,5 +27,9 @@ module CSVImporter
     def after_save(&block)
       config.after_save(block)
     end
+
+    def after_read(&block)
+      config.after_read(block)
+    end
   end
 end


### PR DESCRIPTION
-Adding an `after_read` callback to change the CSV data at runtime
-Adding the methods `add_row` for appending another row to the CSV, `get_from_row_array` as a getter on a single row_array, and `set_in_row_array` as a setter on a single row array.
-Updating spec with tests

Our use case is that we need to support a comma delimited cell in the CSV to cause multiple new records to be saved. `after_read` allows us to make further updates to the CSV data after it has been read, but before any models are built. This way, we can split on the commas in the cell, generate any newly needed rows or updates to the current row, and allow csv-importer to continue working the rest of its magic.