### PR TITLE
Add Custom Cell Sanitize

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,22 @@ You can handle exotic encodings with the `encoding` option.
 ```ruby
 ImportUserCSV.new(content: "メール,氏名".encode('SJIS'), encoding: 'SJIS:UTF-8')
 ```
+### Custom cell sanitising
+
+By default cell values are stripped, that means "  Bob  Elvis " become "Bob  Elvis", however you may want to go further and get rid of the inner extra spaces that often present on cell value and get the proper "Bob Elvis"
+
+To do that, add an initialiser `config/initializers/csv_importer.rb` and define you proper rules.
+
+```
+require 'csv_importer'
+module CSVImporter
+  def self.sanitize_cell(raw_value)
+    raw_value.to_s
+      .gsub(/[\b\s\u00A0]+/, ' ') # Normalize white space
+      .strip # Remove trailing white space
+  end
+end
+```
 
 ## Development
 

--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -30,6 +30,11 @@ require "csv_importer/dsl"
 module CSVImporter
   class Error < StandardError; end
 
+  def self.sanitize_cell(raw_value)
+    raw_value.to_s
+      .strip # Remove trailing white space
+  end
+  
    # Setup DSL and config object
   def self.included(klass)
     klass.extend(Dsl)

--- a/lib/csv_importer/csv_reader.rb
+++ b/lib/csv_importer/csv_reader.rb
@@ -60,7 +60,7 @@ module CSVImporter
     def sanitize_cells(rows)
       rows.map do |cells|
         cells.map do |cell|
-          cell ? cell.strip : ""
+          cell ? CSVImporter.sanitize_cell(cell) : ""
         end
       end
     end


### PR DESCRIPTION
### Custom cell sanitising
 By default cell values are stripped, that means "  Bob  Elvis " become "Bob  Elvis", however you may want to go further and get rid of the inner extra spaces that often present on cell value and get the proper "Bob Elvis"
 To do that, add an initialiser `config/initializers/csv_importer.rb` and define you proper rules.
 ```
require 'csv_importer'
module CSVImporter
  def self.sanitize_cell(raw_value)
    raw_value.to_s
      .gsub(/[\b\s\u00A0]+/, ' ') # Normalize white space
      .strip # Remove trailing white space
  end
end
```