### PR TITLE
Include header info in import report

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -91,7 +91,7 @@ module CSVImporter
   def run!
     if valid_header?
       @report = Runner.call(rows: rows, when_invalid: config.when_invalid,
-                            after_save_blocks: config.after_save_blocks)
+                            after_save_blocks: config.after_save_blocks, report: @report)
     else
       @report
     end


### PR DESCRIPTION
`extra_headers` is available in the report generated by `valid_headers?` but disappears after you call `run!` - seems like valuable information to have available, even after a successful import (which may have ignored extra headers).  This includes the header-related report info in the import report.