### PR TITLE
Make valid_header? handle MalformedCSVErrors

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -85,6 +85,9 @@ module CSVImporter
     end
 
     header.valid?
+  rescue CSV::MalformedCSVError => e
+    @report = Report.new(status: :invalid_csv_file, parser_error: e.message)
+    false
   end
 
   # Run the import. Return a Report.


### PR DESCRIPTION
When you call `run!` on an import with an invalid CSV, it handles MalformedCSVErrors nicely, by returning a report with an error status.  When you call `valid_headers?` it just raises an exception.  This is not what I'd expect.  I'd expect a false response, and a report with a similar error status.  So this does that!