### PR TITLE
Add line number to after build hook

### DIFF
--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -21,7 +21,7 @@ module CSVImporter
 
         set_attributes(model)
 
-        after_build_blocks.each { |block| instance_exec(model, &block) }
+        after_build_blocks.each { |block| instance_exec(model, line_number, &block) }
         model
       end
     end


### PR DESCRIPTION
Passed the line number so it can be consumed by the after_build callback.

In my own code, I'm using this line number to keep a reference to the original csv line that created the record.