### PR TITLE
update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ Or install it yourself as:
 
 ### Create an Importer
 
-Create a class and include `CSVImporter`.
+Require `csv-importer` in your current file ,create a class and include `CSVImporter`.
 
 ```ruby
+require 'csv-importer'
+
 class ImportUserCSV
   include CSVImporter
 end


### PR DESCRIPTION
I'm using the `csv-importer` with `'rails', '~> 6.0.3'` and `ruby '2.7.1'`
while creating an importer I ran into the following error.
`<class:MyImporter>': uninitialized constant MyImporter::CSVImporter (NameError)`
I had to require the `csv-importer` before I could include it in my importer class.
I thought it might be useful to mention that so In this PR I updated the usage section of the README