### PR TITLE
Add possibility to override Row class

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -43,7 +43,6 @@ module CSVImporter
     include Dsl
   end
 
-
   # Defines the path, file or content of the csv file.
   # Also allows you to overwrite the configuration at runtime.
   #
@@ -70,8 +69,8 @@ module CSVImporter
   # Initialize and return the `Row`s for the current CSV file
   def rows
     csv.rows.map.with_index(2) do |row_array, line_number|
-      Row.new(header: header, line_number: line_number, row_array: row_array, model_klass: config.model,
-              identifiers: config.identifiers, after_build_blocks: config.after_build_blocks)
+      config.row_class.new(header: header, line_number: line_number, row_array: row_array, model_klass: config.model,
+              identifiers: config.identifiers, after_build_blocks: config.after_build_blocks) rescue jard
     end
   end
 

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -9,6 +9,7 @@ module CSVImporter
     attribute :when_invalid, Symbol, default: proc { :skip }
     attribute :after_build_blocks, Array[Proc], default: []
     attribute :after_save_blocks, Array[Proc], default: []
+    attribute :row_class, Class, default: Row
 
     def initialize_copy(orig)
       super

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -14,6 +14,10 @@ module CSVImporter
       config.identifiers = params.first.is_a?(Proc) ? params.first : params
     end
 
+    def row_class(row_class)
+      config.row_class = row_class
+    end
+
     alias_method :identifiers, :identifier
 
     def when_invalid(action)

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -14,6 +14,8 @@ module CSVImporter
     attribute :after_build_blocks, Array[Proc], default: []
     attribute :skip, Virtus::Attribute::Boolean, default: false
 
+    delegate :persisted?, :save, to: :model
+
     # The model to be persisted
     def model
       @model ||= begin

--- a/lib/csv_importer/runner.rb
+++ b/lib/csv_importer/runner.rb
@@ -46,7 +46,7 @@ module CSVImporter
         rows.each do |row|
           tags = []
 
-          if row.model.persisted?
+          if row.persisted?
             tags << :update
           else
             tags << :create
@@ -55,7 +55,7 @@ module CSVImporter
           if row.skip?
             tags << :skip
           else
-            if row.model.save
+            if row.save
               tags << :success
             else
               tags << :failure


### PR DESCRIPTION
This PR does basically two things:
 - Saving and `persisted?` check are delegated to Row class
 - When specifying importer you can actually override Row class to use your custom one

What it allows to do:
 - Custom saving logic (by overriding `save` which is by default delegated to model)
 - Custom permissions check (by overriding `skip?` to check what records should be accessible)
 - Overriding model find and model build (which are functions already present in Row class, ``find_model` and `build_model`)

One bit that bothers me using this project among other things is inability to override some parts of model lifecycle. For example, do not save records current user does not have access to, or do some custom object building. 

I believe this is nice set of features for minimal amount of changes. And those are really useful in my case.

What do you think? 