### PR TITLE
Fix/issue with invisible chars

### DIFF
--- a/lib/csv_importer/header.rb
+++ b/lib/csv_importer/header.rb
@@ -9,6 +9,9 @@ module CSVImporter
 
     def columns
       column_names.map do |column_name|
+        # ensure column name escapes invisible characters
+        column_name = column_name.gsub(/\P{Print}|\p{Cf}/, '')
+
         Column.new(
           name: column_name,
           definition: find_column_definition(column_name)

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -425,6 +425,19 @@ bob@example.com   ,  true,   bob   ,,"
     expect { import.run! }.to_not raise_error
   end
 
+  it "supports invisible characters" do
+    csv_content = "Email,Confirmed,First name,last_name
+bob@example.com   ,  true,   bob   ,,"
+
+    # insert invisible characters
+    csv_content.insert(-1, "\u{FEFF}")
+
+    csv_io = StringIO.new(csv_content)
+    import = ImportUserCSV.new(file: csv_io)
+
+    expect { import.run! }.to_not raise_error
+  end
+
   it "imports from a path" do
     import = ImportUserCSV.new(path: "spec/fixtures/valid_csv.csv")
 


### PR DESCRIPTION
Fix issue when comparing column_name with column_definition if there are invisible characters in column_name.

**How to reproduce :**

first column_name => "DATE DU MOIS PRINCIPAL DECLARE"
first column_definition => "DATE DU MOIS PRINCIPAL DECLARE"

first column_definition.codepoints => [68, 65, 84, 69, 32, 68, 85, 32, 77, 79, 73, 83, 32, 80, 82, 73, 78, 67, 73, 80, 65, 76, 32, 68, 69, 67, 76, 65, 82, 69]

first column_name.codepoints => [65279, 68, 65, 84, 69, 32, 68, 85, 32, 77, 79, 73, 83, 32, 80, 82, 73, 78, 67, 73, 80, 65, 76, 32, 68, 69, 67, 76, 65, 82, 69]

