### PR TITLE
Add default_values configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,15 @@ UserImport.new(file: my_file) do
 end
 ```
 
+
+### Set default values
+
+You can set default values for every model record with the `default_values` option:
+
+```ruby
+UserImport.new(file: csv_file, default_values: {batch: '2024a'})
+```
+
 ### Skip import
 
 You can skip the import of a model by calling `skip!` in an

--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -71,7 +71,8 @@ module CSVImporter
   def rows
     csv.rows.map.with_index(2) do |row_array, line_number|
       Row.new(header: header, line_number: line_number, row_array: row_array, model_klass: config.model,
-              identifiers: config.identifiers, after_build_blocks: config.after_build_blocks)
+              identifiers: config.identifiers, after_build_blocks: config.after_build_blocks,
+              default_values: config.default_values)
     end
   end
 

--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -72,6 +72,7 @@ module CSVImporter
     csv.rows.map.with_index(2) do |row_array, line_number|
       Row.new(header: header, line_number: line_number, row_array: row_array, model_klass: config.model,
               identifiers: config.identifiers, after_build_blocks: config.after_build_blocks,
+              after_set_attributes_blocks: config.after_set_attributes_blocks,
               default_values: config.default_values)
     end
   end

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -9,6 +9,7 @@ module CSVImporter
     attribute :when_invalid, Symbol, default: proc { :skip }
     attribute :after_build_blocks, Array[Proc], default: []
     attribute :after_save_blocks, Array[Proc], default: []
+    attribute :default_values, Hash, default: {}
 
     def initialize_copy(orig)
       super

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -8,6 +8,7 @@ module CSVImporter
     attribute :identifiers # Array[Symbol] or Proc
     attribute :when_invalid, Symbol, default: proc { :skip }
     attribute :after_build_blocks, Array[Proc], default: []
+    attribute :after_set_attributes_blocks, Array[Proc], default: []
     attribute :after_save_blocks, Array[Proc], default: []
     attribute :default_values, Hash, default: {}
 
@@ -17,10 +18,15 @@ module CSVImporter
       self.identifiers = orig.identifiers.dup
       self.after_save_blocks = orig.after_save_blocks.dup
       self.after_build_blocks = orig.after_build_blocks.dup
+      self.after_set_attributes_blocks = orig.after_set_attributes_blocks.dup
     end
 
     def after_build(block)
       self.after_build_blocks << block
+    end
+
+    def after_set_attributes(block)
+      self.after_set_attributes_blocks << block
     end
 
     def after_save(block)

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -24,6 +24,10 @@ module CSVImporter
       config.after_build(block)
     end
 
+    def after_set_attributes(&block)
+      config.after_set_attributes(block)
+    end
+
     def after_save(&block)
       config.after_save(block)
     end

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -12,6 +12,7 @@ module CSVImporter
     attribute :model_klass
     attribute :identifiers # Array[Symbol] or Proc
     attribute :after_build_blocks, Array[Proc], default: []
+    attribute :default_values, Hash, default: {}
     attribute :skip, Virtus::Attribute::Boolean, default: false
 
     # The model to be persisted
@@ -107,7 +108,7 @@ module CSVImporter
     end
 
     def build_model
-      model_klass.new
+      model_klass.new(default_values)
     end
 
     def skip!

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -12,6 +12,7 @@ module CSVImporter
     attribute :model_klass
     attribute :identifiers # Array[Symbol] or Proc
     attribute :after_build_blocks, Array[Proc], default: []
+    attribute :after_set_attributes_blocks, Array[Proc], default: []
     attribute :default_values, Hash, default: {}
     attribute :skip, Virtus::Attribute::Boolean, default: false
 
@@ -22,6 +23,7 @@ module CSVImporter
 
         set_attributes(model)
 
+        after_set_attributes_blocks.each { |block| instance_exec(model, &block) }
         after_build_blocks.each { |block| instance_exec(model, &block) }
         model
       end
@@ -97,6 +99,8 @@ module CSVImporter
 
       model = build_model
       set_attributes(model)
+
+      after_set_attributes_blocks.each { |block| instance_exec(model, &block) }
 
       identifiers = model_identifiers(model)
       return nil if identifiers.empty?

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -470,6 +470,18 @@ bob@example.com   ,  true,   bob   , \"the dude\" jones,"
     }.to_not raise_error(NoMethodError, "undefined method `downcase' for nil:NilClass")
   end
 
+  it "sets default attributes" do
+    csv_content = "Email,Confirmed,First name,last_name
+  bob@example.com   ,  true,   bob   ,,"
+    default_values = {created_by_user_id: 123}
+    import = ImportUserCSV.new(content: csv_content, default_values: default_values)
+
+    import.run!
+
+    model = import.report.created_rows.first.model
+    expect(model).to have_attributes({created_by_user_id: 123})
+  end
+
   describe "#when_invalid" do
     it "could abort" do
       csv_content = "email,confirmed,first_name,last_name


### PR DESCRIPTION
This provides a way to set defaults on each model — without adding an extra column to the CSV.

Some potential uses could be batch number, imported_by, etc etc. 